### PR TITLE
スキーマアップロード時にinherit_schema_defaultの更新が漏れていたのを修正

### DIFF
--- a/backendapp/services/JsonToDatabase.ts
+++ b/backendapp/services/JsonToDatabase.ts
@@ -959,6 +959,7 @@ export const schemaListUpdate = async (errorMessages: string[]) => {
 
     let query = `UPDATE jesgo_document_schema SET 
       inherit_schema = '{${numArrayCast2Pg(inheritSchemaList)}}', 
+      inherit_schema_default = '{${numArrayCast2Pg(inheritSchemaList)}}', 
       base_schema = ${undefined2Null(baseSchemaId)}`;
 
     if (!lodash.isEqual(subSchemaList, row.default_sub_s)) {


### PR DESCRIPTION
スキーマアップロード時に今回追加したinherit_schema_defaultの更新が漏れていたせいで
初期設定を反映機能が動作しなくなっていたため修正
