### PR TITLE
リリース対象モジュールにiconv-liteを追加

### DIFF
--- a/export/resource/module_list.txt
+++ b/export/resource/module_list.txt
@@ -55,6 +55,7 @@ graceful-fs
 has-unicode
 helmet
 http-errors
+iconv-lite
 inherits
 ipaddr.js
 is-fullwidth-code-point

--- a/patches/unzipper+0.10.11.patch
+++ b/patches/unzipper+0.10.11.patch
@@ -1,13 +1,20 @@
 diff --git a/node_modules/unzipper/lib/parse.js b/node_modules/unzipper/lib/parse.js
-index bd3b8cc..2f65d3a 100644
+index bd3b8cc..e756944 100644
 --- a/node_modules/unzipper/lib/parse.js
 +++ b/node_modules/unzipper/lib/parse.js
-@@ -105,7 +105,8 @@ Parse.prototype._readFile = function () {
+@@ -9,6 +9,7 @@ var BufferStream = require('./BufferStream');
+ var parseExtraField = require('./parseExtraField');
+ var Buffer = require('./Buffer');
+ var parseDateTime = require('./parseDateTime');
++var iconv = require('iconv-lite');
+ 
+ // Backwards compatibility for node versions < 8
+ if (!Stream.Writable || !Stream.Writable.prototype.destroy)
+@@ -105,7 +106,7 @@ Parse.prototype._readFile = function () {
      if (self.crxHeader) vars.crxHeader = self.crxHeader;
  
      return self.pull(vars.fileNameLength).then(function(fileNameBuffer) {
 -      var fileName = fileNameBuffer.toString('utf8');
-+      var iconv = require('iconv-lite');
 +      var fileName = iconv.decode(fileNameBuffer, 'cp932');
        var entry = Stream.PassThrough();
        var __autodraining = false;


### PR DESCRIPTION
iconv-liteがないとスキーマアップロードに失敗する件を修正
- リリース用モジュール一覧にiconv-liteを追加
- node_modulesにiconv-liteがないと起動できないよう修正