### PR TITLE
アップロードしたZIPファイルに同じ$IDを持つスキーマが2つ以上ある場合の処理を追加

### DIFF
--- a/backendapp/services/JsonToDatabase.ts
+++ b/backendapp/services/JsonToDatabase.ts
@@ -48,7 +48,7 @@ export interface JSONSchema7Object {
 // Workaround for infinite type recursion
 // https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface JSONSchema7Array extends Array<JSONSchema7Type> { }
+export interface JSONSchema7Array extends Array<JSONSchema7Type> {}
 
 /**
  * Meta schema
@@ -114,21 +114,21 @@ export interface JSONSchema7 {
   minProperties?: number | undefined;
   required?: string[] | undefined;
   properties?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
   patternProperties?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
   additionalProperties?: JSONSchema7Definition | undefined;
   dependencies?:
-  | {
-    [key: string]: JSONSchema7Definition | string[];
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition | string[];
+      }
+    | undefined;
   propertyNames?: JSONSchema7Definition | undefined;
 
   /**
@@ -161,10 +161,10 @@ export interface JSONSchema7 {
    * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
    */
   definitions?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
 
   /**
    * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-10
@@ -180,10 +180,10 @@ export interface JSONSchema7 {
    * JSONSchema 未対応プロパティ
    */
   $defs?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
   units?: string | undefined;
 
   /**
@@ -370,10 +370,10 @@ const getOldSchema = async (stringId: string): Promise<oldSchema> => {
     // DB内の日付をGMT+0として認識しているので時差分の修正をする
     const offset = new Date().getTimezoneOffset() * 60 * 1000;
     ret[0].valid_from = new Date(ret[0].valid_from.getTime() - offset);
-    if(ret[0].valid_until) {
+    if (ret[0].valid_until) {
       ret[0].valid_until = new Date(ret[0].valid_until.getTime() - offset);
     }
-    
+
     // 既に存在するschema_string_id
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
     return ret[0];
@@ -496,12 +496,12 @@ const makeInsertQuery = (
   // INSERT
   let query =
     'INSERT INTO jesgo_document_schema (schema_id, schema_id_string, title, subtitle, document_schema';
-  let value = [
+  const value = [
     schemaInfo.schema_id.toString(),
     schemaIdString,
     titles[0],
     subtitle,
-    JSON.stringify(json)
+    JSON.stringify(json),
   ];
 
   if (json['jesgo:unique'] != null) {
@@ -514,7 +514,7 @@ const makeInsertQuery = (
     if (json['jesgo:valid'][0] != null) {
       // 有効期限開始日の指定あり
       query += ', valid_from';
-      value.push(json['jesgo:valid'][0])
+      value.push(json['jesgo:valid'][0]);
 
       const newValidFrom = new Date(json['jesgo:valid'][0]);
       // 旧スキーマと有効期限開始日が同じか、古い場合はエラー
@@ -549,8 +549,8 @@ const makeInsertQuery = (
             );
             subQuery = [
               formatDate(getPreviousDay(new Date(newValidFrom)), '-'),
-              schemaInfo.schema_primary_id.toString()
-            ]
+              schemaInfo.schema_primary_id.toString(),
+            ];
           }
         }
       }
@@ -567,12 +567,15 @@ const makeInsertQuery = (
     // 旧スキーマと有効期限開始日が同じか、古い場合は旧スキーマの翌日を開始日とする
     if (schemaInfo.valid_from >= newValidFrom) {
       newValidFrom = new Date(schemaInfo.valid_from);
-      newValidFrom.setDate(newValidFrom.getDate() + 1)
+      newValidFrom.setDate(newValidFrom.getDate() + 1);
     }
 
     logging(
       LOGTYPE.DEBUG,
-      `スキーマ(id=${schemaIdString})の有効期限開始日を ${formatDate(newValidFrom, '-')} に自動設定`,
+      `スキーマ(id=${schemaIdString})の有効期限開始日を ${formatDate(
+        newValidFrom,
+        '-'
+      )} に自動設定`,
       'JsonToDatabase',
       'makeInsertQuery'
     );
@@ -593,9 +596,8 @@ const makeInsertQuery = (
         );
         subQuery = [
           formatDate(getPreviousDay(new Date(newValidFrom)), '-'),
-          schemaInfo.schema_primary_id.toString()
-        ]
-
+          schemaInfo.schema_primary_id.toString(),
+        ];
       }
     }
     query += ', valid_from';
@@ -679,10 +681,9 @@ const makeInsertQuery = (
   value.push('0');
 
   // valueの項目数で代入項目を生成する
-  query += `) VALUES (${
-    value.map((s, i) => '$' + (i + 1).toString())
-    .join(', ')
-  })`;
+  query += `) VALUES (${value
+    .map((s, i) => '$' + (i + 1).toString())
+    .join(', ')})`;
 
   // 一つでもエラーが出ていたら有効なクエリは返さない
   if (errorFlag) {
@@ -749,10 +750,7 @@ const fileListInsert = async (
       errorMessages
     );
     if (query !== '') {
-      await dbAccess.query(
-        query,
-        values
-      );
+      await dbAccess.query(query, values);
       if (subqueryValues[0] !== '') {
         // 旧スキーマの有効期限更新がある場合そちらも行う
         await dbAccess.query(

--- a/backendapp/services/JsonToDatabase.ts
+++ b/backendapp/services/JsonToDatabase.ts
@@ -48,7 +48,7 @@ export interface JSONSchema7Object {
 // Workaround for infinite type recursion
 // https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface JSONSchema7Array extends Array<JSONSchema7Type> { }
+export interface JSONSchema7Array extends Array<JSONSchema7Type> {}
 
 /**
  * Meta schema
@@ -114,21 +114,21 @@ export interface JSONSchema7 {
   minProperties?: number | undefined;
   required?: string[] | undefined;
   properties?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
   patternProperties?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
   additionalProperties?: JSONSchema7Definition | undefined;
   dependencies?:
-  | {
-    [key: string]: JSONSchema7Definition | string[];
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition | string[];
+      }
+    | undefined;
   propertyNames?: JSONSchema7Definition | undefined;
 
   /**
@@ -161,10 +161,10 @@ export interface JSONSchema7 {
    * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
    */
   definitions?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
 
   /**
    * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-10
@@ -180,10 +180,10 @@ export interface JSONSchema7 {
    * JSONSchema 未対応プロパティ
    */
   $defs?:
-  | {
-    [key: string]: JSONSchema7Definition;
-  }
-  | undefined;
+    | {
+        [key: string]: JSONSchema7Definition;
+      }
+    | undefined;
   units?: string | undefined;
 
   /**
@@ -370,10 +370,10 @@ const getOldSchema = async (stringId: string): Promise<oldSchema> => {
     // DB内の日付をGMT+0として認識しているので時差分の修正をする
     const offset = new Date().getTimezoneOffset() * 60 * 1000;
     ret[0].valid_from = new Date(ret[0].valid_from.getTime() - offset);
-    if(ret[0].valid_until) {
+    if (ret[0].valid_until) {
       ret[0].valid_until = new Date(ret[0].valid_until.getTime() - offset);
     }
-    
+
     // 既に存在するschema_string_id
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
     return ret[0];
@@ -496,12 +496,12 @@ const makeInsertQuery = (
   // INSERT
   let query =
     'INSERT INTO jesgo_document_schema (schema_id, schema_id_string, title, subtitle, document_schema';
-  let value = [
+  const value = [
     schemaInfo.schema_id.toString(),
     schemaIdString,
     titles[0],
     subtitle,
-    JSON.stringify(json)
+    JSON.stringify(json),
   ];
 
   if (json['jesgo:unique'] != null) {
@@ -514,7 +514,7 @@ const makeInsertQuery = (
     if (json['jesgo:valid'][0] != null) {
       // 有効期限開始日の指定あり
       query += ', valid_from';
-      value.push(json['jesgo:valid'][0])
+      value.push(json['jesgo:valid'][0]);
 
       const newValidFrom = new Date(json['jesgo:valid'][0]);
       // 旧スキーマと有効期限開始日が同じか、古い場合はエラー
@@ -549,8 +549,8 @@ const makeInsertQuery = (
             );
             subQuery = [
               formatDate(getPreviousDay(new Date(newValidFrom)), '-'),
-              schemaInfo.schema_primary_id.toString()
-            ]
+              schemaInfo.schema_primary_id.toString(),
+            ];
           }
         }
       }
@@ -567,12 +567,15 @@ const makeInsertQuery = (
     // 旧スキーマと有効期限開始日が同じか、古い場合は旧スキーマの翌日を開始日とする
     if (schemaInfo.valid_from >= newValidFrom) {
       newValidFrom = new Date(schemaInfo.valid_from);
-      newValidFrom.setDate(newValidFrom.getDate() + 1)
+      newValidFrom.setDate(newValidFrom.getDate() + 1);
     }
 
     logging(
       LOGTYPE.DEBUG,
-      `スキーマ(id=${schemaIdString})の有効期限開始日を ${formatDate(newValidFrom, '-')} に自動設定`,
+      `スキーマ(id=${schemaIdString})の有効期限開始日を ${formatDate(
+        newValidFrom,
+        '-'
+      )} に自動設定`,
       'JsonToDatabase',
       'makeInsertQuery'
     );
@@ -593,9 +596,8 @@ const makeInsertQuery = (
         );
         subQuery = [
           formatDate(getPreviousDay(new Date(newValidFrom)), '-'),
-          schemaInfo.schema_primary_id.toString()
-        ]
-
+          schemaInfo.schema_primary_id.toString(),
+        ];
       }
     }
     query += ', valid_from';
@@ -679,10 +681,9 @@ const makeInsertQuery = (
   value.push('0');
 
   // valueの項目数で代入項目を生成する
-  query += `) VALUES (${
-    value.map((s, i) => '$' + (i + 1).toString())
-    .join(', ')
-  })`;
+  query += `) VALUES (${value
+    .map((s, i) => '$' + (i + 1).toString())
+    .join(', ')})`;
 
   // 一つでもエラーが出ていたら有効なクエリは返さない
   if (errorFlag) {
@@ -698,6 +699,7 @@ const fileListInsert = async (
 ): Promise<number> => {
   logging(LOGTYPE.DEBUG, `呼び出し`, 'JsonToDatabase', 'fileListInsert');
   let updateNum = 0;
+  const jsons: JSONSchema7[] = [];
   for (let i = 0; i < fileList.length; i++) {
     if (!fileList[i].endsWith('.json')) {
       logging(
@@ -720,6 +722,7 @@ const fileListInsert = async (
     let json: JSONSchema7 = {};
     try {
       json = JSON.parse(readFileSync(fileList[i], 'utf8')) as JSONSchema7;
+      jsons.push(json);
     } catch {
       logging(
         LOGTYPE.ERROR,
@@ -738,21 +741,57 @@ const fileListInsert = async (
       );
       continue;
     }
+  }
 
+  // jsonファイルを並び替える
+  jsons
+    // 文字列の短い順(よりパスの短い順)に整列
+    .sort(function (a, b) {
+      // $ID順で並び替え
+      if (a.$id && b.$id) {
+        if (a.$id !== b.$id) {
+          if (a.$id > b.$id) return 1;
+          if (a.$id < b.$id) return -1;
+        }
+      }
+
+      // バージョンの比較
+      const versionOfA = a['jesgo:version'];
+      const versionOfB = b['jesgo:version'];
+      if (versionOfA && versionOfB) {
+        // メジャーバージョン順で並び替え
+        if (
+          Number(versionOfA.split('.')[0]) !== Number(versionOfB.split('.')[0])
+        ) {
+          return (
+            Number(versionOfA.split('.')[0]) - Number(versionOfB.split('.')[0])
+          );
+        }
+        // マイナーーバージョン順で並び替え
+        if (
+          Number(versionOfA.split('.')[1]) !== Number(versionOfB.split('.')[1])
+        ) {
+          return (
+            Number(versionOfA.split('.')[1]) - Number(versionOfB.split('.')[1])
+          );
+        }
+      }
+
+      return 0;
+    });
+
+  for (let i = 0; i < jsons.length; i++) {
     // Insert用IDを含む旧データの取得
-    const oldJsonData = await getOldSchema(json.$id as string);
+    const oldJsonData = await getOldSchema(jsons[i].$id as string);
 
     const [query, values, subqueryValues] = makeInsertQuery(
       oldJsonData,
-      json,
+      jsons[i],
       fileList[i],
       errorMessages
     );
     if (query !== '') {
-      await dbAccess.query(
-        query,
-        values
-      );
+      await dbAccess.query(query, values);
       if (subqueryValues[0] !== '') {
         // 旧スキーマの有効期限更新がある場合そちらも行う
         await dbAccess.query(
@@ -769,7 +808,7 @@ const fileListInsert = async (
 /**
  * DBに登録されているスキーマのsubschema, childschema情報をアップデートする
  */
-export const schemaListUpdate = async (errorMessages: string[]) => {
+export const schemaListUpdate = async () => {
   logging(LOGTYPE.DEBUG, `呼び出し`, 'JsonToDatabase', 'schemaListUpdate');
 
   // 先に「子スキーマから指定した親スキーマの関係リスト」を逆にしたものを作成しておく
@@ -1151,7 +1190,7 @@ export const jsonToSchema = async (): Promise<ApiReturnObject> => {
 
     await fileListInsert(fileList, []);
 
-    await schemaListUpdate([]);
+    await schemaListUpdate();
 
     await dbAccess.query('COMMIT');
     return { statusNum: RESULT.NORMAL_TERMINATION, body: null };
@@ -1237,7 +1276,7 @@ export const uploadZipFile = async (data: any): Promise<ApiReturnObject> => {
 
     // スキーマが1件以上新規登録、更新された場合のみ関係性のアップデートを行う
     if (updateNum > 0) {
-      await schemaListUpdate(errorMessages);
+      await schemaListUpdate();
     }
 
     return {

--- a/backendapp/services/Schemas.ts
+++ b/backendapp/services/Schemas.ts
@@ -1,3 +1,4 @@
+import lodash from 'lodash';
 import { logging, LOGTYPE } from '../logic/Logger';
 import { ApiReturnObject, RESULT } from '../logic/ApiCommon';
 import { DbAccess } from '../logic/DbAccess';
@@ -123,25 +124,49 @@ export const getSchemaTree = async (): Promise<ApiReturnObject> => {
     // 保存用オブジェクト
     const schemaTrees: treeSchema[] = [];
 
+    // 無限ループ防止用ブラックリスト
+    const blackList: number[] = [];
+
     // ルートスキーマを順番にツリー用に処理する
     for (let index = 0; index < rootIds.length; index++) {
       const rootId = rootIds[index];
-
-      // 対象のルートスキーマIDに一致するスキーマレコードを取得
-      const rootSchema = allSchemas.find(
-        (schema) => schema.schema_id === rootId
-      );
-
-      if (rootSchema) {
-        // スキーマレコードが取得できた場合、ツリー用に処理する
-        const rootSchemaForTree = schemaRecord2SchemaTree(
-          rootSchema,
-          allSchemas
+      if (!blackList.includes(rootId)) {
+        // 対象のルートスキーマIDに一致するスキーマレコードを取得
+        const rootSchema = allSchemas.find(
+          (schema) => schema.schema_id === rootId
         );
-        schemaTrees.push(rootSchemaForTree);
+
+        if (rootSchema) {
+          // スキーマレコードが取得できた場合、ツリー用に処理する
+          const rootSchemaForTree = schemaRecord2SchemaTree(
+            rootSchema,
+            allSchemas,
+            [0],
+            blackList
+          );
+          if (rootSchemaForTree) {
+            schemaTrees.push(rootSchemaForTree);
+          }
+        }
       }
     }
-    return { statusNum: RESULT.NORMAL_TERMINATION, body: schemaTrees };
+    const errorMessages = [];
+    for (let i = 0; i < blackList.length; i++) {
+      const blackListedSchema = allSchemas.find(
+        (schema) => schema.schema_id === blackList[i]
+      );
+      if (blackListedSchema) {
+        const schemaName = blackListedSchema.subtitle
+          ? `${blackListedSchema.title} ${blackListedSchema.subtitle}`
+          : blackListedSchema.title;
+        const msg = `${schemaName}($id=${blackListedSchema.schema_id_string})について呼び出しがループしています。上位スキーマ、下位スキーマを見直してください。`;
+        errorMessages.push(msg);
+      }
+    }
+    return {
+      statusNum: RESULT.NORMAL_TERMINATION,
+      body: { treeSchema: schemaTrees, errorMessages: errorMessages },
+    };
   } catch (e) {
     logging(
       LOGTYPE.ERROR,
@@ -149,45 +174,63 @@ export const getSchemaTree = async (): Promise<ApiReturnObject> => {
       'Schemas',
       'getScemaTree'
     );
-    return { statusNum: RESULT.ABNORMAL_TERMINATION, body: [] };
+    return {
+      statusNum: RESULT.ABNORMAL_TERMINATION,
+      body: {
+        treeSchema: [],
+        errorMessages: ['スキーマツリーの取得に失敗しました。'],
+      },
+    };
   }
 };
 
 /**
  * スキーマレコード1つと全スキーマを渡すとツリー形式で下位スキーマを取得した状態で返す
- * @param schemarRecord 対象のスキーマレコード
+ * @param schemaRecord 対象のスキーマレコード
  * @param allSchemas 全スキーマのリスト
  * @returns ツリー形式に変換された対象のスキーマレコード
  */
 export const schemaRecord2SchemaTree = (
-  schemarRecord: schemaRecord,
-  allSchemas: schemaRecord[]
-): treeSchema => {
+  schemaRecord: schemaRecord,
+  allSchemas: schemaRecord[],
+  loadedTree: number[],
+  blackList: number[]
+): treeSchema | null => {
+  const tempLoadedTree = lodash.cloneDeep(loadedTree);
+  if (blackList.includes(schemaRecord.schema_id)) {
+    return null;
+  }
+  if (tempLoadedTree.includes(schemaRecord.schema_id)) {
+    blackList.push(schemaRecord.schema_id);
+    return null;
+  } else {
+    tempLoadedTree.push(schemaRecord.schema_id);
+  }
   const subSchemaList = allSchemas.filter((schema) =>
-    schemarRecord.subschema.includes(schema.schema_id)
+    schemaRecord.subschema.includes(schema.schema_id)
   );
   const childSchemaList = allSchemas.filter((schema) =>
-    schemarRecord.child_schema.includes(schema.schema_id)
+    schemaRecord.child_schema.includes(schema.schema_id)
   );
   const inheritSchemaList = allSchemas.filter((schema) =>
-    schemarRecord.inherit_schema.includes(schema.schema_id)
+    schemaRecord.inherit_schema.includes(schema.schema_id)
   );
 
   // サブスキーマ、子スキーマをDBに保存されている順番に並び替え
   subSchemaList.sort(
     (a, b) =>
-      schemarRecord.subschema.indexOf(a.schema_id) -
-      schemarRecord.subschema.indexOf(b.schema_id)
+      schemaRecord.subschema.indexOf(a.schema_id) -
+      schemaRecord.subschema.indexOf(b.schema_id)
   );
   childSchemaList.sort(
     (a, b) =>
-      schemarRecord.child_schema.indexOf(a.schema_id) -
-      schemarRecord.child_schema.indexOf(b.schema_id)
+      schemaRecord.child_schema.indexOf(a.schema_id) -
+      schemaRecord.child_schema.indexOf(b.schema_id)
   );
   inheritSchemaList.sort(
-    (a, b) => 
-    schemarRecord.inherit_schema.indexOf(a.schema_id) - 
-    schemarRecord.inherit_schema.indexOf(b.schema_id)
+    (a, b) =>
+      schemaRecord.inherit_schema.indexOf(a.schema_id) -
+      schemaRecord.inherit_schema.indexOf(b.schema_id)
   );
 
   const subSchemaListWithTree: treeSchema[] = [];
@@ -195,25 +238,46 @@ export const schemaRecord2SchemaTree = (
   const inheritSchemaListWithTree: treeSchema[] = [];
 
   for (let index = 0; index < subSchemaList.length; index++) {
-    const schema = subSchemaList[index];
-    subSchemaListWithTree.push(schemaRecord2SchemaTree(schema, allSchemas));
+    const underTree = schemaRecord2SchemaTree(
+      subSchemaList[index],
+      allSchemas,
+      tempLoadedTree,
+      blackList
+    );
+    if (underTree) {
+      subSchemaListWithTree.push(underTree);
+    }
   }
 
   for (let index = 0; index < childSchemaList.length; index++) {
-    const schema = childSchemaList[index];
-    childSchemaListWithTree.push(schemaRecord2SchemaTree(schema, allSchemas));
+    const underTree = schemaRecord2SchemaTree(
+      childSchemaList[index],
+      allSchemas,
+      tempLoadedTree,
+      blackList
+    );
+    if (underTree) {
+      childSchemaListWithTree.push(underTree);
+    }
   }
 
   for (let index = 0; index < inheritSchemaList.length; index++) {
-    const schema = inheritSchemaList[index];
-    inheritSchemaListWithTree.push(schemaRecord2SchemaTree(schema, allSchemas));
+    const underTree = schemaRecord2SchemaTree(
+      inheritSchemaList[index],
+      allSchemas,
+      tempLoadedTree,
+      blackList
+    );
+    if (underTree) {
+      inheritSchemaListWithTree.push(underTree);
+    }
   }
 
   return {
-    schema_id: schemarRecord.schema_id,
+    schema_id: schemaRecord.schema_id,
     schema_title:
-      schemarRecord.title +
-      (schemarRecord.subtitle.length > 0 ? ' ' + schemarRecord.subtitle : ''),
+      schemaRecord.title +
+      (schemaRecord.subtitle.length > 0 ? ' ' + schemaRecord.subtitle : ''),
     subschema: subSchemaListWithTree,
     childschema: childSchemaListWithTree,
     inheritschema: inheritSchemaListWithTree,
@@ -232,7 +296,12 @@ export const updateSchemas = async (
       // 現状はサブスキーマ、子スキーマのみ、継承スキーマのみ必要に応じて追加
       await dbAccess.query(
         'UPDATE jesgo_document_schema SET subschema = $1, child_schema = $2, inherit_schema = $3 WHERE schema_primary_id = $4',
-        [schema.subschema, schema.child_schema, schema.inherit_schema, schema.schema_primary_id]
+        [
+          schema.subschema,
+          schema.child_schema,
+          schema.inherit_schema,
+          schema.schema_primary_id,
+        ]
       );
     }
 


### PR DESCRIPTION
アップロードしたZIPファイルに同じ$IDを持つスキーマが2つ以上ある場合、バージョン順に古いものから適用していくように修正