### PR TITLE
[ドキュメント出力]非ユニークドキュメントの子ドキュメントが出力されない件を修正

### DIFF
--- a/backendapp/services/Plugin.ts
+++ b/backendapp/services/Plugin.ts
@@ -44,6 +44,7 @@ const generateDocument = (
 ) => {
   const parentDoc = srcDocList.find((p) => p.document_id === docId);
   if (parentDoc) {
+    let pushedObject: any;
     // ユニークな文書か否かで処理を分ける
     if (parentDoc.uniqueness) {
       // unique=trueの場合、基本的にはドキュメントをそのままセットする
@@ -68,13 +69,16 @@ const generateDocument = (
     } else {
       // unique=falseの場合、必ず配列にする
       if (
+        // eslint-disable-next-line no-prototype-builtins
         !(baseObject as object).hasOwnProperty(parentDoc.title) ||
         !Array.isArray(baseObject[parentDoc.title])
       ) {
         baseObject[parentDoc.title] = [];
       }
 
-      baseObject[parentDoc.title].push(parentDoc.document);
+      pushedObject = parentDoc.document;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      baseObject[parentDoc.title].push(pushedObject);
     }
 
     // 子ドキュメント取得
@@ -83,7 +87,10 @@ const generateDocument = (
         generateDocument(
           childDocId,
           srcDocList,
-          baseObject[parentDoc.title] as Obj
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          pushedObject
+            ? (pushedObject as Obj)
+            : (baseObject[parentDoc.title] as Obj)
         );
       });
     }


### PR DESCRIPTION
https://github.com/jesgo-toitu/jesgo-frontend/issues/173#issuecomment-1342185705
上記コメントのドキュメント出力機能のバグを修正

#### 手順・現象
1. 経過 -> 経過・所見 -> PerformanceStatus　のドキュメントを作成し保存
2. 「経過」のメニューからドキュメント出力を実行
→PerformanceStatusの内容が出力されない　※PerformanceStatus以外でも発生

#### 原因
親の「経過・所見」は複数作成可能のため配列で出力しているが、子ドキュメントを追加する際に
配列に子ドキュメントを追加する動きになっていたため正常なObjectと見なされずデータが欠落してしまっていた。
```js
// NGだったオブジェクトの中身
[ { 死亡: false }, PerformanceStatus: 2 ]

// APIからのレスポンス　※PerformanceStatusが消える
[ { 死亡: false } ]

// 本来あるべき姿
[ { 死亡: false, PerformanceStatus: 2 } ]
```

#### 対応
親ドキュメントが配列に格納されている場合、配列内のドキュメントに対して子ドキュメントを追加するよう修正