### PR TITLE
[ドキュメント生成]ユニークなドキュメントがもし複数あった場合の処理に誤りがあったため修正

### DIFF
--- a/backendapp/services/Plugin.ts
+++ b/backendapp/services/Plugin.ts
@@ -50,6 +50,7 @@ const generateDocument = (
       // unique=trueの場合、基本的にはドキュメントをそのままセットする
       // 何かの手違いで複数作成されていた場合は配列にする
       if ((baseObject as object).hasOwnProperty(parentDoc.title)) {
+        pushedObject = parentDoc.document;
         if (!Array.isArray(baseObject[parentDoc.title])) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const tmp = baseObject[parentDoc.title]; // 既存ドキュメントを一旦退避
@@ -58,10 +59,10 @@ const generateDocument = (
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
           baseObject[parentDoc.title].push(tmp);
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-          baseObject[parentDoc.title].push(parentDoc.document);
+          baseObject[parentDoc.title].push(pushedObject);
         } else {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-          baseObject[parentDoc.title].push(parentDoc.document);
+          baseObject[parentDoc.title].push(pushedObject);
         }
       } else {
         baseObject[parentDoc.title] = parentDoc.document;

--- a/backendapp/services/Plugin.ts
+++ b/backendapp/services/Plugin.ts
@@ -74,7 +74,17 @@ const generateDocument = (
         !(baseObject as object).hasOwnProperty(parentDoc.title) ||
         !Array.isArray(baseObject[parentDoc.title])
       ) {
+        let tmp: any;
+        if (baseObject[parentDoc.title]) {
+          // 値があれば一旦退避
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          tmp = baseObject[parentDoc.title];
+        }
         baseObject[parentDoc.title] = [];
+        if (tmp) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          baseObject[parentDoc.title].push(tmp);
+        }
       }
 
       pushedObject = parentDoc.document;


### PR DESCRIPTION
プラグインで使用するドキュメント生成時、ユニークなドキュメントが何らかの理由により複数作成されていた場合に配列にする処理が誤っており、正常なドキュメントが生成されなかったため修正