### PR TITLE
ルートドキュメントがプラグインで更新されるとエラー発生する件を修正

### DIFF
--- a/backendapp/services/Plugin.ts
+++ b/backendapp/services/Plugin.ts
@@ -1190,14 +1190,14 @@ export const updatePluginExecute = async (
             const ret = await changeChildsEventDate(
               documentId,
               documents[index].case_id,
-              parent[0].event_date
+              parent[0]?.event_date
             );
 
             if (oldEventDate !== newEventDate) {
               // 対象のドキュメントすべてのevent_dateを更新する
               await dbAccess.query(
                 'UPDATE jesgo_document SET event_date = $1, last_updated = NOW(), registrant = $2 WHERE document_id = any($3)',
-                [parent[0].event_date, executeUserId, ret.updateDocIds]
+                [parent[0]?.event_date, executeUserId, ret.updateDocIds]
               );
               updatedCaseIdList.add(documents[index].case_id);
             }
@@ -1253,14 +1253,14 @@ export const updatePluginExecute = async (
           const ret = await changeChildsEventDate(
             documentId,
             documents[index].case_id,
-            parent[0].event_date
+            parent[0]?.event_date
           );
 
           if (oldEventDate !== newEventDate) {
             // 対象のドキュメントすべてのevent_dateを更新する
             await dbAccess.query(
               'UPDATE jesgo_document SET event_date = $1, last_updated = NOW(), registrant = $2 WHERE document_id = any($3)',
-              [parent[0].event_date, executeUserId, ret.updateDocIds]
+              [parent[0]?.event_date, executeUserId, ret.updateDocIds]
             );
             updatedCaseIdList.add(documents[index].case_id);
           }


### PR DESCRIPTION
eventdateをAPI側で更新する処理を追加した際のバグを修正

#### 不具合内容
プラグインのデータ更新にてルートドキュメントが更新対象だった場合、eventdateの更新に失敗する

#### 原因
document_idから親のドキュメントを検索していたが、ルートドキュメントのため親はいない。
存在しない親のevent_dateを取得しようとしてエラーになっていた

#### 対応
nullチェック追加