### PR TITLE
スキーマアップロードでjsonファイルを上げた際、tmpフォルダがないとmkdir失敗する問題を修正

### DIFF
--- a/backendapp/services/JsonToDatabase.ts
+++ b/backendapp/services/JsonToDatabase.ts
@@ -1263,7 +1263,7 @@ export const uploadZipFile = async (data: any): Promise<ApiReturnObject> => {
         break;
       case '.json':
         if (!fs.existsSync(dirPath)) {
-          fs.mkdirSync(dirPath);
+          fs.mkdirSync(dirPath, { recursive: true });
         }
         // eslint-disable-next-line
         fs.copyFileSync(filePath, path.join(dirPath, data.originalname));


### PR DESCRIPTION
#### 不具合内容
スキーマアップロードで拡張子.jsonのファイル単体でアップロードした際、バックエンド側にtmpフォルダがないとエラーが発生する

#### 原因
v1.0.3の対応で一時フォルダを`tmp`から`tmp/{uuid}`に変更したが、fs.mkdirSyncがサブディレクトリを作成する設定になっておらずエラーになっていた

#### 対応
`fs.mkdirSync(dirPath, { recursive: true });`のようにrecursiveを設定し、サブディレクトリも作成されるよう修正