### PR TITLE
患者一覧の日付範囲検索時、日付未入力だと日付未入力のデータが検索されない問題を修正

### DIFF
--- a/backendapp/services/SearchPatient.ts
+++ b/backendapp/services/SearchPatient.ts
@@ -131,6 +131,9 @@ const addStatus = (
 const convertSearchDateRange = (dateList: string[]) => {
   let fromDate: Date | undefined;
   let toDate: Date | undefined;
+
+  if (!dateList[0] && !dateList[1]) return { fromDate, toDate };
+
   let fromDateSplited: string[] = [];
   if (dateList.length > 0) {
     // blank or dateFormatString


### PR DESCRIPTION
### 不具合内容
患者一覧で初回治療開始日など日付で検索する場合、範囲検索にチェックをつけて日付は入力しないで検索すると
検索対象の日付が未入力の患者が表示されなくなってしまう

検索日付未入力＝検索条件なしと同じ状態のため、日付が未入力の患者も検索結果に表示されるのが正しい

### 原因
範囲検索にチェックをつけて日付未入力で検索すると、内部的には0001/01/01～9999/12/31の範囲検索になっていたため
日付未入力の患者が引っかからなくなっていた

### 対応
日付検索範囲のFromもToも未入力の場合は検索条件にならないよう修正する
