### PR TITLE
合併症タグ付け(新設)に対応

### DIFF
--- a/backendapp/logic/Utility.ts
+++ b/backendapp/logic/Utility.ts
@@ -22,6 +22,7 @@ export namespace Const {
     REGISTRATION_NUMBER: 'registration_number',
     RECURRENCE: 'recurrence',
     TREATMENT_SURGERY: 'treatment_surgery',
+    SURGIGAL_COMPLICATIONS: 'has_complications',
     TREATMENT_CHEMO: 'treatment_chemo',
     TREATMENT_RADIO: 'treatment_radio',
     TREATMENT_SUPPORTIVECARE: 'treatment_supportivecare',

--- a/backendapp/services/SearchPatient.ts
+++ b/backendapp/services/SearchPatient.ts
@@ -451,7 +451,7 @@ export const searchPatients = async (
         jesgo_tagging(Const.JESGO_TAG.TREATMENT_SUPPORTIVECARE)
       )
     ) {
-      let iconTag:string[] = [];
+      const iconTag: string[] = [];
 
       if (
         docSchema.includes(jesgo_tagging(Const.JESGO_TAG.TREATMENT_SURGERY))
@@ -463,19 +463,21 @@ export const searchPatients = async (
             dbRow.document_schema
           ) ?? '';
         if (tag !== '') {
-          iconTag.push('surgery')
-          
+          iconTag.push('surgery');
+
           if (
-            docSchema.includes(jesgo_tagging(Const.JESGO_TAG.SURGIGAL_COMPLICATIONS))
+            docSchema.includes(
+              jesgo_tagging(Const.JESGO_TAG.SURGIGAL_COMPLICATIONS)
+            )
           ) {
             const subTag =
               getPropertyNameFromTag(
                 Const.JESGO_TAG.SURGIGAL_COMPLICATIONS,
                 dbRow.document,
                 dbRow.document_schema
-              ) ?? 'なし'
+              ) ?? 'なし';
             if (subTag !== 'なし') {
-              iconTag.push('complications')
+              iconTag.push('complications');
             }
           }
         }
@@ -489,7 +491,7 @@ export const searchPatients = async (
             dbRow.document_schema
           ) ?? '';
         if (tag !== '') {
-          iconTag.push('chemo')
+          iconTag.push('chemo');
         }
       } else if (
         docSchema.includes(jesgo_tagging(Const.JESGO_TAG.TREATMENT_RADIO))
@@ -501,7 +503,7 @@ export const searchPatients = async (
             dbRow.document_schema
           ) ?? '';
         if (tag !== '') {
-          iconTag.push('radio')
+          iconTag.push('radio');
         }
       } else if (
         docSchema.includes(
@@ -514,9 +516,9 @@ export const searchPatients = async (
             dbRow.document,
             dbRow.document_schema
           ) ?? '';
-          if (tag !== '') {
-            iconTag.push('supportivecare')
-          }
+        if (tag !== '') {
+          iconTag.push('supportivecare');
+        }
       }
 
       if (iconTag.length > 0) {

--- a/backendapp/services/SearchPatient.ts
+++ b/backendapp/services/SearchPatient.ts
@@ -451,7 +451,7 @@ export const searchPatients = async (
         jesgo_tagging(Const.JESGO_TAG.TREATMENT_SUPPORTIVECARE)
       )
     ) {
-      let iconTag = '';
+      let iconTag:string[] = [];
 
       if (
         docSchema.includes(jesgo_tagging(Const.JESGO_TAG.TREATMENT_SURGERY))
@@ -462,7 +462,23 @@ export const searchPatients = async (
             dbRow.document,
             dbRow.document_schema
           ) ?? '';
-        iconTag = tag !== '' ? 'surgery' : '';
+        if (tag !== '') {
+          iconTag.push('surgery')
+          
+          if (
+            docSchema.includes(jesgo_tagging(Const.JESGO_TAG.SURGIGAL_COMPLICATIONS))
+          ) {
+            const subTag =
+              getPropertyNameFromTag(
+                Const.JESGO_TAG.SURGIGAL_COMPLICATIONS,
+                dbRow.document,
+                dbRow.document_schema
+              ) ?? 'なし'
+            if (subTag !== 'なし') {
+              iconTag.push('complications')
+            }
+          }
+        }
       } else if (
         docSchema.includes(jesgo_tagging(Const.JESGO_TAG.TREATMENT_CHEMO))
       ) {
@@ -472,7 +488,9 @@ export const searchPatients = async (
             dbRow.document,
             dbRow.document_schema
           ) ?? '';
-        iconTag = tag !== '' ? 'chemo' : '';
+        if (tag !== '') {
+          iconTag.push('chemo')
+        }
       } else if (
         docSchema.includes(jesgo_tagging(Const.JESGO_TAG.TREATMENT_RADIO))
       ) {
@@ -482,7 +500,9 @@ export const searchPatients = async (
             dbRow.document,
             dbRow.document_schema
           ) ?? '';
-        iconTag = tag !== '' ? 'radio' : '';
+        if (tag !== '') {
+          iconTag.push('radio')
+        }
       } else if (
         docSchema.includes(
           jesgo_tagging(Const.JESGO_TAG.TREATMENT_SUPPORTIVECARE)
@@ -494,21 +514,23 @@ export const searchPatients = async (
             dbRow.document,
             dbRow.document_schema
           ) ?? '';
-        iconTag = tag !== '' ? 'supportivecare' : '';
+          if (tag !== '') {
+            iconTag.push('supportivecare')
+          }
       }
 
-      if (iconTag !== '') {
+      if (iconTag.length > 0) {
         // 再発系の場合
         if (recurrenceChildDocumentIds.includes(dbRow.document_id)) {
-          userData.postRelapseTreatment.push(iconTag);
+          userData.postRelapseTreatment.push(...iconTag);
         }
         // 初回治療の場合
         else {
-          userData.initialTreatment.push(iconTag);
+          userData.initialTreatment.push(...iconTag);
         }
 
         // どちらでもステータスに入れる
-        userData.status.push(iconTag);
+        userData.status.push(...iconTag);
       }
     }
 


### PR DESCRIPTION
デモ画面で存在していて、準備までしていたものの実装されていなかった手術合併症ステータスアイコンの表示を実装。

- 併せてスキーマに埋め込むタグに "has_complication" を追加しました(APIドキュメント対応御願いします)。
- フロントエンドはそのまま対応出来るので修正は必要ありません。