### PR TITLE
がん種の検索リストが消えてしまう問題を修正

### DIFF
--- a/backendapp/logic/Utility.ts
+++ b/backendapp/logic/Utility.ts
@@ -36,7 +36,7 @@ export const jesgo_tagging = (tag: string): string => {
 };
 
 export const escapeText = (text: string): string => {
-  return text.replace('"', '\\"');
+  return text.replace(/"/g, '\\"');
 };
 
 // 現在日付とN年の差があるかを確認する

--- a/backendapp/services/JsonToDatabase.ts
+++ b/backendapp/services/JsonToDatabase.ts
@@ -1166,10 +1166,10 @@ export const updateSearchColumn = async (): Promise<void> => {
     `SELECT document_schema 
     FROM view_latest_schema 
     WHERE document_schema->>'properties' like '%${escapeText(
-      jesgo_tagging(Const.JESGO_TAG.CANCER_MAJOR)
+      `"${Const.JESGO_TAG.CANCER_MAJOR}"`
     )}%' 
     OR document_schema->>'properties' like '%${escapeText(
-      jesgo_tagging(Const.JESGO_TAG.CANCER_MINOR)
+      `"${Const.JESGO_TAG.CANCER_MINOR}"`
     )}%' 
     AND schema_id <> 0 
     ORDER BY schema_id_string;`


### PR DESCRIPTION
https://github.com/jesgo-toitu/jesgo-frontend/issues/297
上記課題の修正
- SQLでの抽出条件を"cancer_major"と"cancer_minor"のみに修正
- ダブルクオーテーションのエスケープも始めの文字しか置換されていなかったため修正

#### その他改善
- 毎回DELETE→INSERTしていたため、現在のリストとスキーマから生成したリストが異なる場合にDELETE→INSERTするよう修正