### PR TITLE
新しいボキャブラリ jesgo:inheriteventdate とその関連を実装

### DIFF
--- a/backendapp/services/JsonToDatabase.ts
+++ b/backendapp/services/JsonToDatabase.ts
@@ -211,6 +211,7 @@ export interface JSONSchema7 {
   'jesgo:valid'?: string[] | undefined;
   'jesgo:version'?: string | undefined;
   'jesgo:author'?: string | undefined;
+  'jesgo:inheriteventdate'?: string | undefined;
 }
 
 type oldSchema = {


### PR DESCRIPTION
新しいボキャブラリ jesgo:inheriteventdate を実装。
- jesgo:inheriteventdate
  - 値: 'inherit'|'clear'
    - **inherit**
      - 親ドキュメントのeventdateをchild_schemaのドキュメント中の```"jesgo:set": "eventdate"```を無視してデータベースに保存する
      - ドキュメント上の値は変更されない
    - **clear**
      - child_schemaにeventdateがあればドキュメントのeventdateは```"jesgo:set": "eventdate"```のある日付プロパティに従う

あわせてeventdateの再帰的更新についてもコードを変更、データベースに記録されるeventdateはスキーマの系譜に従う。