### PR TITLE
dev-#352-旧プラグイン変更、削除フラグ更新

### DIFF
--- a/doc/DB/batch/install_all.bat
+++ b/doc/DB/batch/install_all.bat
@@ -13,3 +13,15 @@ cd ..\
 cd .\beta3
 call DB更新.bat
 cd ..\
+
+cd .\beta4
+call DB更新.bat
+cd ..\
+
+cd .\ver111
+call DB更新.bat
+cd ..\
+
+cd .\ver120
+call DB更新.bat
+cd ..\

--- a/doc/DB/batch/ver120/DB更新.bat
+++ b/doc/DB/batch/ver120/DB更新.bat
@@ -54,3 +54,18 @@ IF %errorlevel% neq 0 (
 ) ELSE (
   echo データ更新成功
 )
+
+rem データ更新2
+if exist C:\jesgo\pgsql\bin\psql.exe (
+	C:\jesgo\pgsql\bin\psql.exe -f .\update_jesgo_plugin.sql -U postgres -d jesgo_db
+) else (
+	C:\jesgo\postgres\pgsql\bin\psql.exe -f .\update_jesgo_plugin.sql -U postgres -d jesgo_db
+)
+IF %errorlevel% neq 0 (
+
+  ECHO %date% %time:~0,8% 実行に失敗しました  ErrorCode=%errorlevel%^
+  FileName「%SQLFILE%」 >> %~DP0\log/psql_log.txt
+
+) ELSE (
+  echo データ更新2成功
+)

--- a/doc/DB/batch/ver120/update_jesgo_plugin.sql
+++ b/doc/DB/batch/ver120/update_jesgo_plugin.sql
@@ -1,0 +1,26 @@
+UPDATE public.jesgo_plugin
+SET deleted = true
+WHERE plugin_name in
+(
+	'子宮頸がん登録確認 (2023-2024)',
+	'子宮体がん登録確認 (2023-2024)',
+	'卵巣がん登録確認 (2023-2024)',
+	'外部スクリプトの実行',
+	'外部スクリプトの実行(個別)'
+);
+
+UPDATE public.jesgo_plugin
+SET plugin_name = '子宮頸がん個別チェック(2023-2024)'
+WHERE plugin_name = '子宮頸がん個別確認 (2023-2024)';
+
+UPDATE public.jesgo_plugin
+SET plugin_name = '子宮体がん個別チェック(2023-2024)'
+WHERE plugin_name = '子宮体がん個別確認 (2023-2024)';
+
+UPDATE public.jesgo_plugin
+SET plugin_name = '卵巣がん個別チェック(2023-2024)'
+WHERE plugin_name = '卵巣がん個別確認 (2023-2024)';
+
+UPDATE public.jesgo_plugin
+SET plugin_name = '患者文書出力(個別)'
+WHERE plugin_name = '単一患者のJESGO JSONドキュメント出力';


### PR DESCRIPTION
バージョンアップの際に旧プラグインの名称が変更が発生したため、旧プラグインの名称変更、および不要なプラグインの削除フラグを更新するスクリプトを適用致しました。

Fixes https://github.com/jesgo-toitu/jesgo-frontend/issues/352