### PR TITLE
#373 ポート番号設定の外部設定化

### DIFF
--- a/backendapp/app.ts
+++ b/backendapp/app.ts
@@ -1,26 +1,31 @@
-// ライブラリ読み込み
+// プロセス名の設定
+process.title = "JESGO-Server";
+
+// ライブラリの読み込み
 import express from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import bodyParser from 'body-parser';
 import router from './routes/';
 import { logging, LOGTYPE } from './logic/Logger';
+import envVariables from './config';
 const app = express();
 app.use(helmet());
 app.use(cors());
 
-//body-parserの設定
+// body-parserの設定
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }));
 app.use(bodyParser.json({ limit: '1mb' }));
 
-const port = process.env.PORT || 3000; // port番号を指定
+// port番号の設定
+const port = envVariables.serverPort || process.env.JESGO_SERVER_PORT || 3000;
 
 // ------ ルーティング ------ //
 app.use('/', router);
 
-//サーバ起動
+// サーバ起動
 app.listen(port);
 logging(LOGTYPE.INFO, `listen on port ${port}`);
 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-console.log(`express: start. port=${port}, mode=${app.get('env')}`);
+console.log(`express: start. port=${port}, mode=${app.get('env')}, node=${process.execPath}`);
 console.log('JESGO サーバー起動中...');

--- a/backendapp/config/config.json
+++ b/backendapp/config/config.json
@@ -1,9 +1,12 @@
 {
-    "database": "jesgo_db",
-    "user": "postgres",
-    "password": "12345678",
-    "host": "localhost",
-    "port": 5432,
-    "passwordSalt": "abcde",
-    "hashSalt": "3^0g#H-x$M"
+    "server": {
+        "database": "jesgo_db",
+        "user": "postgres",
+        "password": "12345678",
+        "host": "localhost",
+        "port": 5432,
+        "passwordSalt": "abcde",
+        "hashSalt": "3^0g#H-x$M",
+        "serverPort": 3000
+    }
 }

--- a/backendapp/config/index.ts
+++ b/backendapp/config/index.ts
@@ -8,14 +8,23 @@ export type EnvVariables = {
   port: number;
   passwordSalt: string;
   hashSalt: string;
+  serverPort: number;
   privateKey: string;
   publicKey: string;
 };
 
 import * as fs from 'fs';
 
+const _pathJson = fs
+  .readFileSync('./package.json')
+  .toString();
+const pathJson = JSON.parse(_pathJson);
+const configPath = process.env.NODE_ENV === 'production' ?
+  pathJson['config']['configPath']['production'] :
+  pathJson['config']['configPath']['development'];
+
 const _configJson: string = fs
-  .readFileSync('./backendapp/config/config.json')
+  .readFileSync(configPath as string || './backendapp/config/config.json')
   .toString();
 const _privateKey: string = fs
   .readFileSync('./backendapp/config/keys/private.key')
@@ -27,13 +36,14 @@ const configJson = JSON.parse(_configJson);
 
 const envVariables = (): EnvVariables => {
   return {
-    database: configJson['database'],
-    user: configJson['user'],
-    password: configJson['password'],
-    host: configJson['host'],
-    port: configJson['port'],
-    passwordSalt: configJson['passwordSalt'],
-    hashSalt: configJson['hashSalt'],
+    database: configJson['server']['database'],
+    user: configJson['server']['user'],
+    password: configJson['server']['password'],
+    host: configJson['server']['host'],
+    port: configJson['server']['port'],
+    passwordSalt: configJson['server']['passwordSalt'],
+    hashSalt: configJson['server']['hashSalt'],
+    serverPort: configJson['server']['serverPort'],
     privateKey: _privateKey,
     publicKey: _publicKey,
   };

--- a/export/export.ps1
+++ b/export/export.ps1
@@ -5,8 +5,8 @@ Remove-item .\release -Recurse -Force
 
 # ディレクトリを再生成
 New-Item release -ItemType Directory
-# バックエンドファイルの主要ファイルから.ts(トランスパイル前ファイル)、.key(秘密鍵ファイル)以外をコピーする
-Copy-Item -Exclude ("*.ts", "*.key") -Path ..\backendapp\ -Destination .\release\ -Recurse
+# バックエンドファイルの主要ファイルから.ts(トランスパイル前ファイル)、.key(秘密鍵ファイル)、設定ファイル以外をコピーする
+Copy-Item -Exclude ("*.ts", "*.key", "config.json") -Path ..\backendapp\ -Destination .\release\ -Recurse
 
 # その他単体ファイルをコピーする
 Copy-Item -Path ..\package.json -Destination .\release\

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
         }
     },
     "scripts": {
-        "start": "cmd /c \"if defined PATH_NODE (\"%PATH_NODE%\" ./backendapp/app.js) else (node ./backendapp/app.js)\"",
+        "start": "cmd /c \"if defined PATH_NODE (\"\"%PATH_NODE%\"\" ./backendapp/app.js) else (node ./backendapp/app.js)\"",
         "dev-start": "node ./backendapp/app.js",
         "prod-start": "cross-env NODE_ENV=production node ./backendapp/app.js",
         "build": "npx tsc",
         "lint": "eslint --ext .tsx,.ts backendapp/",
         "fmt": "prettier --write backendapp/**/*",
         "test": "jest",
-        "install-service": "winser -i --env \"NODE_ENV=%NODE_ENV%\" --env \"PATH_NODE=%PATH_NODE%\"",
+        "install-service": "winser -i",
         "uninstall-service": "winser -r -x",
         "postinstall": "patch-package"
     },

--- a/package.json
+++ b/package.json
@@ -25,15 +25,21 @@
             "**/tests/**/*.test.ts"
         ]
     },
+    "config": {
+        "configPath": {
+            "development": "./backendapp/config/config.json",
+            "production": "../config/config.json"
+        }
+    },
     "scripts": {
-        "start": "C:\\jesgo\\node\\node-v20.18.0-win-x64\\node ./backendapp/app.js",
+        "start": "cmd /c \"if defined PATH_NODE (\"%PATH_NODE%\" ./backendapp/app.js) else (node ./backendapp/app.js)\"",
         "dev-start": "node ./backendapp/app.js",
         "prod-start": "cross-env NODE_ENV=production node ./backendapp/app.js",
         "build": "npx tsc",
         "lint": "eslint --ext .tsx,.ts backendapp/",
         "fmt": "prettier --write backendapp/**/*",
         "test": "jest",
-        "install-service": "winser -i",
+        "install-service": "winser -i --env \"NODE_ENV=%NODE_ENV%\" --env \"PATH_NODE=%PATH_NODE%\"",
         "uninstall-service": "winser -r -x",
         "postinstall": "patch-package"
     },


### PR DESCRIPTION
① WebApp、Serverアプリケーションの設定ファイル(config.json)を共通化して外部化する
両アプリケーションの設定項目を統合して、下記のように相対パスで参照する。
開発モード：既存のパスを参照
本番モード：../config/config.json
※配布資源の場合、rootフォルダ直下に対して上記パスに設定ファイルを配置する。
　配布資源作成スクリプト(export.ps1)にて、config.jsonを除外して資源には同梱しない。
※開発モード、本番モードの相対パスはpackage.jsonのconfigにて管理。
※WebApp側のexpressにて、提供する設定ファイルはモードによって切り替える。
※package.jsonのconfig情報は、サービス実行時(winser経由)に読み込まれないため、
　package.jsonを読み込みconfig情報を取得するよう処理を共通化。

② package.jsonのスクリプトにて、nodeの実行パスを環境変数化する
配布資源のenv.batにて、環境変数「PATH_NODE」に実行パスを設定して、
スクリプト実行時にPATH_NODEを指定してnodeを実行する。
※PATH_NODEが未定義の場合、PATH_NODEは指定せず既存通りnodeを実行。
※サービス実行時は、サービス登録時に指定したモード、node実行パスを適用。