### PR TITLE
jesgo:errorのリスト生成におけるハンドリングを変更

### DIFF
--- a/backendapp/services/SearchPatient.ts
+++ b/backendapp/services/SearchPatient.ts
@@ -4,6 +4,7 @@ import { ApiReturnObject, RESULT } from '../logic/ApiCommon';
 import { logging, LOGTYPE } from '../logic/Logger';
 import { Const, isAgoYearFromNow, jesgo_tagging } from '../logic/Utility';
 import { getItemsAndNames, JSONSchema7 } from './JsonToDatabase';
+import { error } from 'console';
 
 //インターフェース
 export interface dbRow {
@@ -569,8 +570,20 @@ export const searchPatients = async (
 
     // エラー有無(ここのみスキーマではなくドキュメントを見る)
     if (document.includes('jesgo:error')) {
-      userData.registration.push('has_error');
-    }
+      // ドキュメントにjesgo:errorの文字列があった場合はエラーの状態を確認する
+      try {
+        const parsedDocument = JSON.parse(document);
+        const errorProperty = parsedDocument['jesgo:error'];
+
+        if (Array.isArray(errorProperty) && errorProperty.length > 0) {
+          // エラー項目がある場合はhas_errorを追加
+          userData.registration.push('has_error');
+        } else if (errorProperty !== null && (typeof errorProperty === 'string' && errorProperty.trim() !== '')) {
+          // エラーがある場合はhas_errorを追加
+          userData.registration.push('has_error');
+        }
+      } catch {}
+    } 
 
     // 腫瘍登録番号登録有無
     if (docSchema.includes(jesgo_tagging(Const.JESGO_TAG.REGISTRABILITY))) {

--- a/backendapp/services/SearchPatient.ts
+++ b/backendapp/services/SearchPatient.ts
@@ -570,7 +570,7 @@ export const searchPatients = async (
 
     // エラー有無(ここのみスキーマではなくドキュメントを見る)
     if (document.includes('jesgo:error')) {
-      // ドキュメントにjesgo:errorの文字列があった場合はエラーの状態を確認する
+      // ドキュメントにjesgo:errorの文字列があった場合はエラーの状態を確認する為に展開する
       try {
         const parsedDocument = JSON.parse(document);
         const errorProperty = parsedDocument['jesgo:error'];

--- a/backendapp/services/SearchPatient.ts
+++ b/backendapp/services/SearchPatient.ts
@@ -568,21 +568,14 @@ export const searchPatients = async (
       userData.status.push('recurrence');
     }
 
-    // エラー有無(ここのみスキーマではなくドキュメントを見る)
-    if (document.includes('jesgo:error')) {
-      // ドキュメントにjesgo:errorの文字列があった場合はエラーの状態を確認する為に展開する
-      try {
-        const parsedDocument = JSON.parse(document);
-        const errorProperty = parsedDocument['jesgo:error'];
+    // エラー有無フラグの設定
+    if (typeof (dbRow.document as any) === 'object' && (dbRow.document as any)['jesgo:error']) {
+      const errorProperty = (dbRow.document as any)['jesgo:error']
 
-        if (Array.isArray(errorProperty) && errorProperty.length > 0) {
-          // エラー項目がある場合はhas_errorを追加
-          userData.registration.push('has_error');
-        } else if (errorProperty !== null && (typeof errorProperty === 'string' && errorProperty.trim() !== '')) {
-          // エラーがある場合はhas_errorを追加
-          userData.registration.push('has_error');
-        }
-      } catch {}
+      if (Array.isArray(errorProperty) && errorProperty.filter(item => item != null).length > 0) {
+        // エラー項目がある場合はhas_errorを追加
+        userData.registration.push('has_error');
+      }
     } 
 
     // 腫瘍登録番号登録有無


### PR DESCRIPTION
フラグ設定のjesgo:errorの判定を厳格化した。
現状：
- ドキュメント文字列に jesgo:error の文字列があればエラーと判定
改善：
- ドキュメント文字列に jesgo:error の文字列があったらJSONを展開して、jesgo:error の値が有意であればエラーと判定
